### PR TITLE
Use correct and valid KEYWORD_TOKENTYPEs in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,5 +1,5 @@
 Arduino_Nano_Play_Board	KEYWORD1
 getLightValue	KEYWORD2
-getPotentiometerValue	KEYWORD3
-setTone	KEYWORD4
-setPixel	KEYWORD5
+getPotentiometerValue	KEYWORD2
+setTone	KEYWORD2
+setPixel	KEYWORD2


### PR DESCRIPTION
Use of the undocumented KEYWORD4 has the unexpected result of coloring the keyword as an inline comment in Arduino IDE 1.6.4 and older. Use of the undocumented KEYWORD5 has the unexpected result of coloring the keyword as a hyperlink in Arduino IDE 1.6.4 and older.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keyword_tokentype